### PR TITLE
Convert the "direct use" of lwjgl to GlStateManager.

### DIFF
--- a/src/watson/LiteModWatson.java
+++ b/src/watson/LiteModWatson.java
@@ -18,6 +18,7 @@ import com.mumfrey.liteloader.util.ObfuscationUtilities;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.entity.EntityPlayerSP;
 import net.minecraft.client.multiplayer.ServerData;
+import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.OpenGlHelper;
 import net.minecraft.client.renderer.RenderHelper;
 import net.minecraft.client.settings.KeyBinding;
@@ -256,19 +257,19 @@ public class LiteModWatson implements JoinGameListener, ChatFilter, Tickable, Po
       RenderHelper.disableStandardItemLighting();
       OpenGlHelper.setLightmapTextureCoords(OpenGlHelper.lightmapTexUnit, 240, 240);
 
-      GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
-      GL11.glEnable(GL11.GL_BLEND);
-      GL11.glDisable(GL11.GL_TEXTURE_2D);
-      GL11.glDisable(GL11.GL_LIGHTING);
-      GL11.glDepthMask(false);
-      GL11.glDisable(GL11.GL_DEPTH_TEST);
+      GlStateManager.blendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
+      GlStateManager.enableBlend();
+      GlStateManager.disableTexture2D();
+      GlStateManager.disableLighting();
+      GlStateManager.depthMask(false);
+      GlStateManager.disableDepth();
 
       boolean foggy = GL11.glIsEnabled(GL11.GL_FOG);
-      GL11.glDisable(GL11.GL_FOG);
+      GlStateManager.disableFog();
 
-      GL11.glPushMatrix();
+      GlStateManager.pushMatrix();
 
-      GL11.glTranslated(
+      GlStateManager.translate(
         -getPlayerX(partialTicks),
         -getPlayerY(partialTicks),
         -getPlayerZ(partialTicks));
@@ -288,7 +289,7 @@ public class LiteModWatson implements JoinGameListener, ChatFilter, Tickable, Po
       // tess.addVertex(-5, 27, 5);
       // tess.draw();
 
-      GL11.glPopMatrix();
+      GlStateManager.popMatrix();
 
       edits.drawAnnotations();
       edits.getOreDB().drawDepositLabels();
@@ -301,13 +302,13 @@ public class LiteModWatson implements JoinGameListener, ChatFilter, Tickable, Po
       // Or else, fog is *all* you'll see with Optifine.
       if (foggy)
       {
-        GL11.glEnable(GL11.GL_FOG);
+          GlStateManager.enableFog();
       }
-      GL11.glEnable(GL11.GL_DEPTH_TEST);
-      GL11.glDepthMask(true);
-      GL11.glEnable(GL11.GL_LIGHTING);
-      GL11.glEnable(GL11.GL_TEXTURE_2D);
-      GL11.glDisable(GL11.GL_BLEND);
+      GlStateManager.enableDepth();
+      GlStateManager.depthMask(true);
+      GlStateManager.enableLighting();
+      GlStateManager.enableTexture2D();
+      GlStateManager.disableBlend();
 
       RenderHelper.enableStandardItemLighting();
     }

--- a/src/watson/db/Annotation.java
+++ b/src/watson/db/Annotation.java
@@ -2,6 +2,7 @@ package watson.db;
 
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.FontRenderer;
+import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.client.renderer.WorldRenderer;
 import net.minecraft.client.renderer.entity.RenderManager;
@@ -134,27 +135,27 @@ public class Annotation
       dl = far;
     }
 
-    GL11.glPushMatrix();
+    GlStateManager.pushMatrix();
 
     double scale = (0.05 * dl + 1.0) * scaleFactor;
-    GL11.glTranslated(dx, dy, dz);
-    GL11.glRotatef(-renderManager.playerViewY, 0.0f, 1.0f, 0.0f);
-    GL11.glRotatef(
+    GlStateManager.translate(dx, dy, dz);
+    GlStateManager.rotate(-renderManager.playerViewY, 0.0f, 1.0f, 0.0f);
+    GlStateManager.rotate(
       mc.gameSettings.thirdPersonView != 2 ? renderManager.playerViewX
         : -renderManager.playerViewX, 1.0f, 0.0f, 0.0f);
-    GL11.glScaled(-scale, -scale, scale);
-    GL11.glDisable(GL11.GL_LIGHTING);
-    GL11.glEnable(GL11.GL_BLEND);
-    GL11.glBlendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
+    GlStateManager.scale(-scale, -scale, scale);
+    GlStateManager.disableLighting();
+    GlStateManager.disableBlend();
+    GlStateManager.blendFunc(GL11.GL_SRC_ALPHA, GL11.GL_ONE_MINUS_SRC_ALPHA);
     Tessellator tessellator = Tessellator.getInstance();
       WorldRenderer wr = tessellator.getWorldRenderer();
 
     int textWidth = fontRenderer.getStringWidth(text) >> 1;
     if (textWidth != 0)
     {
-      GL11.glDisable(GL11.GL_TEXTURE_2D);
-      GL11.glDisable(GL11.GL_DEPTH_TEST);
-      GL11.glDepthMask(false);
+      GlStateManager.disableTexture2D();
+      GlStateManager.disableDepth();
+      GlStateManager.depthMask(false);
 
       // Draw background plate.
         wr.startDrawingQuads();
@@ -166,18 +167,18 @@ public class Annotation
       tessellator.draw();
 
       // Draw text.
-      GL11.glEnable(GL11.GL_TEXTURE_2D);
-      GL11.glColor4f(1.0f, 1.0f, 1.0f, 1.0f);
+      GlStateManager.enableTexture2D();
+      GlStateManager.color(1.0f, 1.0f, 1.0f, 1.0f);
       fontRenderer.drawString(text, -textWidth, -5, fgARGB);
-      GL11.glEnable(GL11.GL_DEPTH_TEST);
-      GL11.glDepthMask(true);
+      GlStateManager.enableDepth();
+      GlStateManager.depthMask(true);
     }
 
-    GL11.glDisable(GL11.GL_BLEND);
-    GL11.glColor4f(1.0f, 1.0f, 1.0f, 1.0f);
-    GL11.glEnable(GL11.GL_TEXTURE_2D);
-    GL11.glEnable(GL11.GL_LIGHTING);
-    GL11.glPopMatrix();
+    GlStateManager.disableBlend();
+    GlStateManager.color(1.0f, 1.0f, 1.0f, 1.0f);
+    GlStateManager.enableTexture2D();
+    GlStateManager.enableLighting();
+    GlStateManager.popMatrix();
   } // drawBillboard
 
   // --------------------------------------------------------------------------

--- a/src/watson/db/BlockEditSet.java
+++ b/src/watson/db/BlockEditSet.java
@@ -17,6 +17,7 @@ import java.util.regex.Pattern;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.ScaledResolution;
 
+import net.minecraft.client.renderer.GlStateManager;
 import org.lwjgl.opengl.GL11;
 
 import watson.Configuration;
@@ -393,7 +394,7 @@ public class BlockEditSet
   {
     try
     {
-      GL11.glPushMatrix();
+      GlStateManager.pushMatrix();
 
       Minecraft mc = Minecraft.getMinecraft();
       ScaledResolution scaledResolution = new ScaledResolution(mc, mc.displayWidth, mc.displayHeight);
@@ -401,7 +402,7 @@ public class BlockEditSet
     }
     finally
     {
-      GL11.glPopMatrix();
+      GlStateManager.popMatrix();
     }
   } // drawHUD
 


### PR DESCRIPTION
Mojang recently introduced the GlStateManager into their codebase.
This actually handles GL calls a bit smarter by caching and checking before everything is sent off to lwjgl.

However this does in turn then cause problems for mods/plugins that don't use the GlStateManager class or work around it. The issue comes from mods that for example bind textures or change colors (or even just glEnable/glDisable) stuff, and minecraft not changing stuff before rendering because it did not know about it.

This is most notable when you for example use the voxel minimap. Waypoint beacons tend to flicker/render oddly when the watson renderer is being used.

This pull request changes most of the GL calls I found that have GlStateManager methods that do (more or less) the same.